### PR TITLE
Add Windows CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test .NET
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '*.md'
+      - 'Docs/**'
+      - 'Examples/**'
+      - '.gitignore'
+  pull_request:
+    branches:
+      - master
+
+env:
+  DOTNET_VERSIONS: |
+    8.0.x
+    9.0.x
+  BUILD_CONFIGURATION: 'Release'
+
+jobs:
+  test-windows:
+    name: 'Windows'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSIONS }}
+
+      - name: Restore dependencies
+        run: dotnet restore LocalSecurityEditor.sln
+
+      - name: Build solution
+        run: dotnet build LocalSecurityEditor.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+      - name: Test net472
+        run: dotnet test LocalSecurityEditor.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --framework net472
+
+      - name: Test net8.0
+        run: dotnet test LocalSecurityEditor.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --framework net8.0

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -8,7 +8,7 @@ using LocalSecurityEditor;
 namespace TestApp {
     internal class Program {
         static void Main() {
-            /Example1();
+            //Example1();
             Example2_ExternalComputer();
             ExampleCoversion();
         }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test on Windows for .NET Framework 4.7.2 and .NET 8
- fix sample project to compile by properly commenting out Example1

## Testing
- `dotnet build LocalSecurityEditor.sln --configuration Release`
- `dotnet test LocalSecurityEditor.sln --configuration Release --no-build --framework net472`
- `dotnet test LocalSecurityEditor.sln --configuration Release --no-build --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68979e24d108832e92691cb467ce1302