### PR TITLE
Add argument validation for service SID generation

### DIFF
--- a/LocalSecurityEditor.Tests/LocalSecurityEditor.Tests.csproj
+++ b/LocalSecurityEditor.Tests/LocalSecurityEditor.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LocalSecurityEditor\LocalSecurityEditor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/LocalSecurityEditor.Tests/NTServiceTests.cs
+++ b/LocalSecurityEditor.Tests/NTServiceTests.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+
+namespace LocalSecurityEditor.Tests;
+
+public class NTServiceTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void GenerateSID_InvalidServiceName_ThrowsArgumentException(string? serviceName)
+    {
+        Assert.Throws<ArgumentException>(() => NTService.GenerateSID(serviceName!));
+    }
+}
+

--- a/LocalSecurityEditor.sln
+++ b/LocalSecurityEditor.sln
@@ -7,20 +7,54 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalSecurityEditor", "Loca
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "TestApp\TestApp.csproj", "{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocalSecurityEditor.Tests", "LocalSecurityEditor.Tests\LocalSecurityEditor.Tests.csproj", "{79E3D70A-838A-40D2-AE2D-B03C793FDD34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Debug|x86.Build.0 = Debug|Any CPU
 		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|x64.Build.0 = Release|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{74D9A5F3-1C53-4AB1-9234-3E7487AB7B6B}.Release|x86.Build.0 = Release|Any CPU
 		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|x64.Build.0 = Debug|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Debug|x86.Build.0 = Debug|Any CPU
 		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|x64.ActiveCfg = Release|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|x64.Build.0 = Release|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{48D6B1BC-EE16-4994-AEE0-5751E34C78B5}.Release|x86.Build.0 = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|x64.Build.0 = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Debug|x86.Build.0 = Debug|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|x64.ActiveCfg = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|x64.Build.0 = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|x86.ActiveCfg = Release|Any CPU
+		{79E3D70A-838A-40D2-AE2D-B03C793FDD34}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LocalSecurityEditor/NTService.cs
+++ b/LocalSecurityEditor/NTService.cs
@@ -20,6 +20,7 @@ namespace LocalSecurityEditor {
         /// </code>
         /// </example>
         public static string GenerateSID(string serviceName) {
+            if (string.IsNullOrWhiteSpace(serviceName)) throw new ArgumentException(nameof(serviceName));
             using (SHA1Managed sha1 = new SHA1Managed()) {
                 byte[] serviceNameBytes = Encoding.Unicode.GetBytes(serviceName.ToUpper());
                 byte[] hash = sha1.ComputeHash(serviceNameBytes);


### PR DESCRIPTION
## Summary
- guard `NTService.GenerateSID` against null or whitespace names
- add xUnit tests for invalid service name inputs

## Testing
- `dotnet build`
- `dotnet test -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6897a0e6416c832e8f1aeb055bda147b