### PR TITLE
Add input validation for InitLsaString and tests

### DIFF
--- a/LocalSecurityEditor.Tests/LsaWrapperTests.cs
+++ b/LocalSecurityEditor.Tests/LsaWrapperTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Reflection;
+
+namespace LocalSecurityEditor.Tests;
+
+public class LsaWrapperTests
+{
+    [Fact]
+    public void InitLsaString_NullString_ThrowsArgumentNullException()
+    {
+        var method = typeof(LsaWrapper).GetMethod("InitLsaString", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(null, new object?[] { null }));
+        Assert.IsType<ArgumentNullException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void InitLsaString_EmptyString_ThrowsArgumentNullException()
+    {
+        var method = typeof(LsaWrapper).GetMethod("InitLsaString", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(null, new object[] { string.Empty }));
+        Assert.IsType<ArgumentNullException>(ex.InnerException);
+    }
+}

--- a/LocalSecurityEditor/LsaWrapper.cs
+++ b/LocalSecurityEditor/LsaWrapper.cs
@@ -368,7 +368,18 @@ namespace LocalSecurityEditor {
             return lts.Sid;
         }
 
+        /// <summary>
+        /// Creates an <see cref="LSA_UNICODE_STRING"/> from the specified string.
+        /// </summary>
+        /// <param name="s">The string to convert.</param>
+        /// <returns>The initialized <see cref="LSA_UNICODE_STRING"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="s"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the string exceeds 32 KB.</exception>
         private static LSA_UNICODE_STRING InitLsaString(string s) {
+            if (string.IsNullOrEmpty(s)) {
+                throw new ArgumentNullException(nameof(s));
+            }
+
             // Unicode strings max. 32KB
             if (s.Length > 0x7ffe)
                 throw new ArgumentException("String too long");


### PR DESCRIPTION
## Summary
- validate LSA string initialization against null or empty values
- add tests for InitLsaString validation

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6897bd03f860832ebb2d606429630b7a