### PR TITLE
Add service SID tests across frameworks

### DIFF
--- a/LocalSecurityEditor.Tests/LocalSecurityEditor.Tests.csproj
+++ b/LocalSecurityEditor.Tests/LocalSecurityEditor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/LocalSecurityEditor.Tests/ServiceSidTests.cs
+++ b/LocalSecurityEditor.Tests/ServiceSidTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace LocalSecurityEditor.Tests;
+
+public class ServiceSidTests
+{
+    [Theory]
+    [InlineData("ADSync", "S-1-5-80-3245704983-3664226991-764670653-2504430226-901976451")]
+    [InlineData("MSSQLSERVER", "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003")]
+    [InlineData("W32Time", "S-1-5-80-4267341169-2882910712-659946508-2704364837-2204554466")]
+    [InlineData("TrustedInstaller", "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464")]
+    public void GenerateSID_KnownServiceName_ReturnsExpectedSid(string serviceName, string expectedSid)
+    {
+        string sid = NTService.GenerateSID(serviceName);
+        Assert.Equal(expectedSid, sid);
+    }
+}


### PR DESCRIPTION
## Summary
- move service SID validation into the existing test project
- verify service name to SID mapping for ADSync, MSSQLSERVER, W32Time, and TrustedInstaller across net472, net8.0, and net9.0

## Testing
- `dotnet build -v minimal`
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6897bcf01170832e9d3f4a427a522567