### PR TITLE
Ensure Win32SecurityIdentifier frees pinned handles

### DIFF
--- a/LocalSecurityEditor.Tests/Win32SecurityIdentifierTests.cs
+++ b/LocalSecurityEditor.Tests/Win32SecurityIdentifierTests.cs
@@ -1,0 +1,45 @@
+using System;
+using LocalSecurityEditor;
+using Xunit;
+
+namespace LocalSecurityEditor.Tests;
+
+public class Win32SecurityIdentifierTests
+{
+#if NETFRAMEWORK
+    [Fact(Skip = "Pinned object count not available on .NET Framework")]
+    public void Finalizer_FreesPinnedHandle_NoDispose()
+    {
+    }
+#else
+    [Fact]
+    public void Finalizer_FreesPinnedHandle_NoDispose()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long pinnedBefore = GC.GetGCMemoryInfo().PinnedObjectsCount;
+
+        var sid = new Win32SecurityIdentifier("S-1-5-18");
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long pinnedDuring = GC.GetGCMemoryInfo().PinnedObjectsCount;
+        GC.KeepAlive(sid);
+        Assert.True(pinnedDuring > pinnedBefore);
+
+        sid = null;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long pinnedAfter = GC.GetGCMemoryInfo().PinnedObjectsCount;
+        Assert.Equal(pinnedBefore, pinnedAfter);
+    }
+#endif
+}

--- a/LocalSecurityEditor/Win32SecurityIdentifier.cs
+++ b/LocalSecurityEditor/Win32SecurityIdentifier.cs
@@ -56,6 +56,10 @@ namespace LocalSecurityEditor {
             }
         }
 
+        ~Win32SecurityIdentifier() {
+            Dispose(false);
+        }
+
         /// <summary>
         /// Disposes of an object
         /// </summary>
@@ -67,7 +71,7 @@ namespace LocalSecurityEditor {
         protected virtual void Dispose(bool disposing) {
             if (disposed) return;
 
-            if (disposing && handle.IsAllocated)
+            if (handle.IsAllocated)
                 handle.Free();
 
             disposed = true;


### PR DESCRIPTION
## Summary
- add finalizer that calls Dispose(false)
- free GC handle regardless of disposing
- add test verifying handles are released after GC collection

## Testing
- `dotnet build LocalSecurityEditor.sln -c Release`
- `dotnet test LocalSecurityEditor.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6897c391d314832eae50d3f7f29317e3