### PR TITLE
Refactor LsaWrapper domain parsing

### DIFF
--- a/LocalSecurityEditor.Tests/LsaWrapperTests.cs
+++ b/LocalSecurityEditor.Tests/LsaWrapperTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace LocalSecurityEditor.Tests;
 
@@ -21,5 +22,18 @@ public class LsaWrapperTests
         Assert.NotNull(method);
         var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(null, new object[] { string.Empty }));
         Assert.IsType<ArgumentNullException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void GetPrivileges_ReturnsDomainQualifiedNames()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        using var lsa = new LsaWrapper();
+        var accounts = lsa.GetPrivileges(UserRightsAssignment.SeServiceLogonRight);
+        Assert.All(accounts, account => Assert.Contains("\\", account));
     }
 }


### PR DESCRIPTION
## Summary
- simplify `GetPrivileges` by using a single `LSA_REFERENCED_DOMAIN_LIST` for domain lookups
- build domain-qualified account names from `LSA_TRUST_INFORMATION`
- add unit test ensuring privilege lookups return domain-qualified accounts

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6897c6addaf0832e943bbd5e8aadd32c