### PR TITLE
Add service SID resolution helper and tests

### DIFF
--- a/LocalSecurityEditor.Tests/ServiceSidTests.cs
+++ b/LocalSecurityEditor.Tests/ServiceSidTests.cs
@@ -1,9 +1,10 @@
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace LocalSecurityEditor.Tests;
 
-public class ServiceSidTests
-{
+    public class ServiceSidTests
+    {
     [Theory]
     [InlineData("ADSync", "S-1-5-80-3245704983-3664226991-764670653-2504430226-901976451")]
     [InlineData("MSSQLSERVER", "S-1-5-80-3880718306-3832830129-1677859214-2598158968-1052248003")]
@@ -13,5 +14,21 @@ public class ServiceSidTests
     {
         string sid = NTService.GenerateSID(serviceName);
         Assert.Equal(expectedSid, sid);
+    }
+
+    [Theory]
+    [InlineData("S-1-5-80-4267341169-2882910712-659946508-2704364837-2204554466", "W32Time")]
+    [InlineData("S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464", "TrustedInstaller")]
+    public void ResolveServiceName_KnownSid_ReturnsExpectedServiceName(string sid, string expectedServiceName)
+    {
+        string? serviceName = NTService.ResolveServiceName(sid);
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Null(serviceName);
+            return;
+        }
+
+        Assert.Equal(expectedServiceName, serviceName);
     }
 }

--- a/LocalSecurityEditor/LocalSecurityEditor.csproj
+++ b/LocalSecurityEditor/LocalSecurityEditor.csproj
@@ -29,10 +29,11 @@
 		<ProduceReferenceAssembly>False</ProduceReferenceAssembly>
 
 		<PackageReadmeFile>README.MD</PackageReadmeFile>
-		<RepositoryType>git</RepositoryType>
-		<SignAssembly>False</SignAssembly>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-	</PropertyGroup>
+                <RepositoryType>git</RepositoryType>
+                <SignAssembly>False</SignAssembly>
+                <GenerateDocumentationFile>True</GenerateDocumentationFile>
+                <LangVersion>latest</LangVersion>
+        </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
 		<WarningLevel>4</WarningLevel>

--- a/LocalSecurityEditor/NTService.cs
+++ b/LocalSecurityEditor/NTService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace LocalSecurityEditor {
@@ -34,5 +35,74 @@ namespace LocalSecurityEditor {
                 return sb.ToString();
             }
         }
+
+        /// <summary>
+        /// Resolves a service name from a provided service SID.
+        /// </summary>
+        /// <param name="sid">String representation of a service SID.</param>
+        /// <returns>The service name if resolved; otherwise, <c>null</c>.</returns>
+        /// <example>
+        /// <code>
+        /// string sid = "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
+        /// string? serviceName = NTService.ResolveServiceName(sid);
+        /// Console.WriteLine("The service for SID '" + sid + "' is: " + serviceName);
+        /// </code>
+        /// </example>
+        public static string? ResolveServiceName(string sid) {
+            if (string.IsNullOrWhiteSpace(sid)) throw new ArgumentException(nameof(sid));
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                return null;
+            }
+
+            if (!ConvertStringSidToSid(sid, out IntPtr sidPtr)) {
+                return null;
+            }
+
+            try {
+                uint nameLen = 0;
+                uint domainLen = 0;
+                SID_NAME_USE use;
+
+                LookupAccountSid(null, sidPtr, null, ref nameLen, null, ref domainLen, out use);
+
+                StringBuilder name = new StringBuilder((int)nameLen);
+                StringBuilder domain = new StringBuilder((int)domainLen);
+
+                if (!LookupAccountSid(null, sidPtr, name, ref nameLen, domain, ref domainLen, out use)) {
+                    return null;
+                }
+
+                if (domain.ToString().Equals("NT SERVICE", StringComparison.OrdinalIgnoreCase)) {
+                    return name.ToString();
+                }
+
+                return domain + "\\" + name;
+            } finally {
+                LocalFree(sidPtr);
+            }
+        }
+
+        private enum SID_NAME_USE : uint {
+            SidTypeUser = 1,
+            SidTypeGroup,
+            SidTypeDomain,
+            SidTypeAlias,
+            SidTypeWellKnownGroup,
+            SidTypeDeletedAccount,
+            SidTypeInvalid,
+            SidTypeUnknown,
+            SidTypeComputer,
+            SidTypeLabel
+        }
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool LookupAccountSid(string? lpSystemName, IntPtr Sid, StringBuilder? Name, ref uint cchName, StringBuilder? ReferencedDomainName, ref uint cchReferencedDomainName, out SID_NAME_USE peUse);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool ConvertStringSidToSid(string StringSid, out IntPtr Sid);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr hMem);
     }
 }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -35,6 +35,9 @@ namespace TestApp {
             string serviceSid4 = NTService.GenerateSID(serviceName4);
             Console.WriteLine($"The SID for the service '{serviceName4}' is: {serviceSid4} {serviceExpectedSid4} {(serviceSid4 == serviceExpectedSid4)}");
 
+            string trustedInstallerSid = "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
+            string? trustedInstallerName = NTService.ResolveServiceName(trustedInstallerSid);
+            Console.WriteLine($"The service for the SID '{trustedInstallerSid}' is: {trustedInstallerName}");
         }
 
         private static void Example1() {


### PR DESCRIPTION
## Summary
- expose `NTService.ResolveServiceName` to translate service SIDs using Windows APIs
- verify reverse mapping of service SIDs in `ServiceSidTests`
- show resolving service SID in TestApp example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6898293477d4832ea17ac85d8fabd17e